### PR TITLE
enable `shapefile`'s `geo-types` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-shapefile = "0.4.0"
+shapefile = { version = "0.4.0", features = ["geo-types"] }
 geo = "0.24.1"
 geo-types = "0.7.9"
 anyhow = "1"


### PR DESCRIPTION
The `shapefile` crate has an optional dependency on the `geo-types` crate, which is necessary to use the conversions between `shapefile`'s types and `geo-types`'s types. This optional dependency is not enabled by default, so it must be enabled in the `Cargo.toml` file explicitly to use these conversions.

Unfortunately, the `shapefile` crate's docs don't state this, and the RustDoc feature that would automatically generate a note in the docs indicating that the optional dependency is required is not enabled, so it took a little digging through the code upstream to figure this out. If we take a look at `shapefile`'s `Cargo.toml`, we can see that the `geo-types` dependency is declared as optional: https://github.com/tmontaigu/shapefile-rs/blob/e73ca33fcb42df581565482facc97444a7c8c236/Cargo.toml#L17

This branch enables the `geo-types` feature on `shapefile`, enabling the optional dependency and allowing us to use conversion methods between `shapefile` and `geo-types` types.